### PR TITLE
Add compatibility for the mod Lootr.

### DIFF
--- a/src/main/java/shadows/placebo/util/ChestBuilder.java
+++ b/src/main/java/shadows/placebo/util/ChestBuilder.java
@@ -12,6 +12,7 @@ import net.minecraft.loot.LootEntry;
 import net.minecraft.loot.functions.EnchantRandomly;
 import net.minecraft.loot.functions.ILootFunction;
 import net.minecraft.tileentity.ChestTileEntity;
+import net.minecraft.tileentity.LockableLootTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
@@ -28,6 +29,8 @@ public class ChestBuilder {
 	protected Random random;
 	protected ChestTileEntity chest;
 	protected boolean isValid;
+	protected BlockPos position;
+	protected IWorld iWorld;
 
 	public ChestBuilder(IWorld world, Random rand, BlockPos pos) {
 		TileEntity tileEntity = world.getTileEntity(pos);
@@ -35,6 +38,8 @@ public class ChestBuilder {
 			random = rand;
 			chest = (ChestTileEntity) tileEntity;
 			isValid = true;
+			position = pos;
+			iWorld = world;
 		}
 	}
 
@@ -47,7 +52,11 @@ public class ChestBuilder {
 	}
 
 	public void fill(ResourceLocation loot) {
-		chest.setLootTable(loot, random.nextLong());
+		if (iWorld != null) {
+			LockableLootTileEntity.setLootTable(iWorld, random, position, loot);
+		} else {
+			chest.setLootTable(loot, random.nextLong());
+		}
 	}
 
 	public static LootEntry loot(Item item, int min, int max, int weight, int quality) {


### PR DESCRIPTION
Lootr hooks primarily off of `LockableLootTileEntity`'s static `setLootTable` method as the member method doesn't contain the correct world for replacement. Attempts to hook off the latter generally require weird magic.

Functionally this is identical, although in your use-case it's slightly more cumbersome visually.

Unfortunateley the second constructor does become slightly problematic. I'm not sure how much this is used throughout your mods, so I've supported both instances.

I may also be insane.

Disclaimer: I wasn't able to fully test it because I can't get Placebo to compile due to dependency issues.