### PR TITLE
Remove unused duplicate keymappings

### DIFF
--- a/src/main/java/shadows/placebo/patreon/PatreonUtils.java
+++ b/src/main/java/shadows/placebo/patreon/PatreonUtils.java
@@ -18,9 +18,6 @@ import shadows.placebo.patreon.wings.Wing;
 
 public class PatreonUtils {
 
-	public static final KeyMapping TOGGLE_T = new KeyMapping("placebo.toggleTrails", GLFW.GLFW_KEY_KP_8, "key.categories.placebo");
-	public static final KeyMapping TOGGLE_W = new KeyMapping("placebo.toggleWings", GLFW.GLFW_KEY_KP_9, "key.categories.placebo");
-
 	public static enum PatreonParticleType {
 		ASH(() -> ParticleTypes.ASH),
 		CAMPFIRE_SMOKE(() -> ParticleTypes.CAMPFIRE_COSY_SMOKE),


### PR DESCRIPTION
This should resolve #66 for 1.19.2. There is a bug with forge when duplicate keymappings are defined for the same key that one of them don't get the clickCount updated.
Issue is better explained: https://github.com/MinecraftForge/MinecraftForge/pull/9360

This seems to be fixed in 1.19.4 and above by: https://github.com/MinecraftForge/MinecraftForge/commit/cf3d42ef38df29b53076e0016cd3a6d8cd7269d6