### PR TITLE
[1.19] Backport lazy initialization of cached objects map

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## 7.3.5
+* Made CachedObject lazy-init the ConcurrentHashMap stored on ItemStack.
+
 ## 7.3.4
 * Fixed the Supporter Trail / Wing keybinds causing a crash if pressed before entering the world.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ modGroup=shadows
 modid=placebo
 author=Shadows_of_Fire
 desc=1 (one) library boi
-version=7.3.4
+version=7.3.5
 
 # Dependencies
 mcVersion=1.19.2

--- a/src/main/java/shadows/placebo/mixin/ItemStackMixin.java
+++ b/src/main/java/shadows/placebo/mixin/ItemStackMixin.java
@@ -21,7 +21,7 @@ import shadows.placebo.util.CachedObject.CachedObjectSource;
 @Mixin(ItemStack.class)
 public class ItemStackMixin implements CachedObjectSource {
 
-	public Map<ResourceLocation, CachedObject<?>> cachedObjects = new ConcurrentHashMap<>();
+	private volatile Map<ResourceLocation, CachedObject<?>> cachedObjects = null;
 
 	@Inject(at = @At("HEAD"), method = "useOn(Lnet/minecraft/world/item/context/UseOnContext;)Lnet/minecraft/world/InteractionResult;", cancellable = true)
 	public void placebo_itemUseHook(UseOnContext ctx, CallbackInfoReturnable<InteractionResult> cir) {
@@ -32,8 +32,17 @@ public class ItemStackMixin implements CachedObjectSource {
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getOrCreate(ResourceLocation id, Function<ItemStack, T> deserializer, ToIntFunction<ItemStack> hasher) {
-		var cachedObj = this.cachedObjects.computeIfAbsent(id, key -> new CachedObject<>(key, deserializer, hasher));
+		var cachedObj = this.getOrCreate().computeIfAbsent(id, key -> new CachedObject<>(key, deserializer, hasher));
 		return (T) cachedObj.get((ItemStack) (Object) this);
+	}
+
+	private Map<ResourceLocation, CachedObject<?>> getOrCreate() {
+		if (this.cachedObjects == null) {
+			synchronized (this) {
+				if (this.cachedObjects == null) this.cachedObjects = new ConcurrentHashMap<>();
+			}
+		}
+		return this.cachedObjects;
 	}
 
 }

--- a/src/main/java/shadows/placebo/util/CachedObject.java
+++ b/src/main/java/shadows/placebo/util/CachedObject.java
@@ -34,8 +34,8 @@ public final class CachedObject<T> {
 	protected final Function<ItemStack, T> deserializer;
 	protected final ToIntFunction<ItemStack> hasher;
 
-	protected T data = null;
-	protected int lastNbtHash = HAS_NEVER_BEEN_INITIALIZED;
+	protected volatile T data = null;
+	protected volatile int lastNbtHash = HAS_NEVER_BEEN_INITIALIZED;
 
 	/**
 	 * Creates a new CachedObject.


### PR DESCRIPTION
Manual backport of https://github.com/Shadows-of-Fire/Placebo/commit/1fe6155e80b1630da87f820c2aa6b17f1cdb411d to 1.19. Should help a bit with memory usage in large modpacks.