### PR TITLE
PlaceboTaskQueue - Fix delayed task never running attached task

### DIFF
--- a/src/main/java/dev/shadowsoffire/placebo/util/PlaceboTaskQueue.java
+++ b/src/main/java/dev/shadowsoffire/placebo/util/PlaceboTaskQueue.java
@@ -71,7 +71,7 @@ public class PlaceboTaskQueue {
         @Override
         public Status execute() {
             if (delay-- > 0) {
-                return Status.COMPLETED;
+                return Status.RUNNING;
             }
             return this.task.execute();
         }


### PR DESCRIPTION
Currently the delayed task marks itself instantly completed on first run, never actually running the attached task. Marking as running allows it to work as expected.